### PR TITLE
Add support for air time and runtime

### DIFF
--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -6,9 +6,12 @@ class Episode < ApplicationRecord
   validates :season_number, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validates :episode_number, presence: true, numericality: { greater_than: 0 }
   validates :air_date, presence: true
+  validates :runtime_minutes, numericality: { greater_than: 0 }, allow_nil: true
 
   scope :upcoming, -> { where("air_date >= ?", Date.current) }
   scope :aired, -> { where("air_date < ?", Date.current) }
+  scope :upcoming_with_time, -> { where("air_datetime_utc >= ?", Time.current.utc) }
+  scope :aired_with_time, -> { where("air_datetime_utc < ?", Time.current.utc) }
 
   def episode_code
     "#{season_number.to_s.rjust(2, '0')}x#{episode_number.to_s.rjust(2, '0')}"
@@ -22,5 +25,25 @@ class Episode < ApplicationRecord
 
   def location_text
     "#{title} - (#{episode_code})"
+  end
+
+  def air_time_in_timezone(target_timezone = "America/New_York")
+    return nil unless air_datetime_utc.present?
+    air_datetime_utc.in_time_zone(target_timezone)
+  end
+
+  def end_time_in_timezone(target_timezone = "America/New_York")
+    return nil unless air_datetime_utc.present? && runtime_minutes.present?
+    start_time = air_time_in_timezone(target_timezone)
+    start_time + runtime_minutes.minutes
+  end
+
+  def has_specific_air_time?
+    air_datetime_utc.present?
+  end
+
+  def runtime_duration
+    return nil unless runtime_minutes.present?
+    runtime_minutes.minutes
   end
 end

--- a/app/services/ics_generator.rb
+++ b/app/services/ics_generator.rb
@@ -100,7 +100,20 @@ class IcsGenerator
         .gsub(/\r/, "")
   end
 
+  # US DST rules as defined by Energy Policy Act of 2005
+  # DST begins: Second Sunday in March at 2:00 AM
+  # DST ends: First Sunday in November at 2:00 AM
+  # These rules have been stable since 2007 and are unlikely to change
+  # If DST rules change, update these constants
+  DST_START_RULE = "FREQ=YEARLY;BYMONTH=3;BYDAY=2SU".freeze
+  DST_END_RULE = "FREQ=YEARLY;BYMONTH=11;BYDAY=1SU".freeze
+  DST_TRANSITION_TIME = "T020000".freeze
+
   def new_york_timezone_definition
+    # Generate timezone definition using current US DST rules
+    # Reference: https://www.timeanddate.com/time/change/usa
+    base_year = 2007 # Year current DST rules took effect
+    
     [
       "BEGIN:VTIMEZONE",
       "TZID:America/New_York",
@@ -108,15 +121,15 @@ class IcsGenerator
       "TZOFFSETFROM:-0500",
       "TZOFFSETTO:-0400",
       "TZNAME:EDT",
-      "DTSTART:20070311T020000",
-      "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU",
+      "DTSTART:#{base_year}0311#{DST_TRANSITION_TIME}",
+      "RRULE:#{DST_START_RULE}",
       "END:DAYLIGHT",
       "BEGIN:STANDARD",
       "TZOFFSETFROM:-0400",
       "TZOFFSETTO:-0500", 
       "TZNAME:EST",
-      "DTSTART:20071104T020000",
-      "RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU",
+      "DTSTART:#{base_year}1104#{DST_TRANSITION_TIME}",
+      "RRULE:#{DST_END_RULE}",
       "END:STANDARD",
       "END:VTIMEZONE"
     ]

--- a/app/services/ics_generator.rb
+++ b/app/services/ics_generator.rb
@@ -65,14 +65,14 @@ class IcsGenerator
       else
         # Fallback to all-day if time parsing failed
         date_start = episode.air_date.strftime("%Y%m%d")
-        date_end = episode.air_date.strftime("%Y%m%d")
+        date_end = (episode.air_date + 1.day).strftime("%Y%m%d")
         event << "DTSTART;VALUE=DATE:#{date_start}"
         event << "DTEND;VALUE=DATE:#{date_end}"
       end
     else
       # All-day event (current behavior)
       date_start = episode.air_date.strftime("%Y%m%d")
-      date_end = episode.air_date.strftime("%Y%m%d")
+      date_end = (episode.air_date + 1.day).strftime("%Y%m%d")
       event << "DTSTART;VALUE=DATE:#{date_start}"
       event << "DTEND;VALUE=DATE:#{date_end}"
     end

--- a/app/services/ics_generator.rb
+++ b/app/services/ics_generator.rb
@@ -47,12 +47,12 @@ class IcsGenerator
       # Get air time in New York timezone as specified in the issue
       start_time_ny = episode.air_time_in_timezone("America/New_York")
       end_time_ny = episode.end_time_in_timezone("America/New_York")
-      
+
       if start_time_ny.present?
         # Format as datetime with timezone for ICS
         dtstart = start_time_ny.strftime("%Y%m%dT%H%M%S")
         event << "DTSTART;TZID=America/New_York:#{dtstart}"
-        
+
         if end_time_ny.present?
           dtend = end_time_ny.strftime("%Y%m%dT%H%M%S")
           event << "DTEND;TZID=America/New_York:#{dtend}"
@@ -113,7 +113,7 @@ class IcsGenerator
     # Generate timezone definition using current US DST rules
     # Reference: https://www.timeanddate.com/time/change/usa
     base_year = 2007 # Year current DST rules took effect
-    
+
     [
       "BEGIN:VTIMEZONE",
       "TZID:America/New_York",
@@ -126,7 +126,7 @@ class IcsGenerator
       "END:DAYLIGHT",
       "BEGIN:STANDARD",
       "TZOFFSETFROM:-0400",
-      "TZOFFSETTO:-0500", 
+      "TZOFFSETTO:-0500",
       "TZNAME:EST",
       "DTSTART:#{base_year}1104#{DST_TRANSITION_TIME}",
       "RRULE:#{DST_END_RULE}",

--- a/app/services/user_sync_service.rb
+++ b/app/services/user_sync_service.rb
@@ -1,4 +1,25 @@
 class UserSyncService
+  # Network timezone mappings for common TV networks
+  # Based on typical broadcast timezones and network headquarters
+  # Update this hash when adding support for new networks or regions
+  NETWORK_TIMEZONE_MAPPINGS = {
+    # Premium Cable Networks (East Coast based)
+    %w[HBO SHOWTIME STARZ EPIX] => "America/New_York",
+    
+    # Cable Networks (East Coast based)
+    %w[MTV VH1 FX AMC TNT TBS USA SYFY] => "America/New_York",
+    ["COMEDY CENTRAL"] => "America/New_York",
+    
+    # Major Broadcast Networks (Eastern time reference)
+    %w[FOX ABC CBS NBC CW PBS] => "America/New_York",
+    
+    # Children's Networks
+    %w[DISNEY NICKELODEON CARTOON] => "America/New_York",
+    
+    # Streaming Services (typically use Eastern for premieres)
+    %w[NETFLIX HULU AMAZON PRIME] => "America/New_York"
+  }.freeze
+
   def initialize(user)
     @user = user
     @client = TvdbClient.new
@@ -188,16 +209,17 @@ class UserSyncService
   end
 
   def guess_timezone_from_network(network)
-    # Map common networks to their typical timezones
-    case network.to_s.upcase
-    when /HBO|SHOWTIME|MTV|VH1|COMEDY CENTRAL|FX|AMC/
-      "America/New_York"  # East Coast
-    when /FOX|ABC|CBS|NBC|CW/
-      "America/New_York"  # Major networks typically reference Eastern
-    when /DISNEY|NICKELODEON/
-      "America/New_York"
-    else
-      nil # Let caller use default
+    return nil if network.blank?
+    
+    # Find matching timezone from network mappings
+    network_upper = network.to_s.upcase
+    
+    NETWORK_TIMEZONE_MAPPINGS.each do |networks, timezone|
+      if networks.any? { |net| network_upper.include?(net) }
+        return timezone
+      end
     end
+    
+    nil # Let caller use default
   end
 end

--- a/app/services/user_sync_service.rb
+++ b/app/services/user_sync_service.rb
@@ -5,17 +5,17 @@ class UserSyncService
   NETWORK_TIMEZONE_MAPPINGS = {
     # Premium Cable Networks (East Coast based)
     %w[HBO SHOWTIME STARZ EPIX] => "America/New_York",
-    
+
     # Cable Networks (East Coast based)
     %w[MTV VH1 FX AMC TNT TBS USA SYFY] => "America/New_York",
-    ["COMEDY CENTRAL"] => "America/New_York",
-    
+    [ "COMEDY CENTRAL" ] => "America/New_York",
+
     # Major Broadcast Networks (Eastern time reference)
     %w[FOX ABC CBS NBC CW PBS] => "America/New_York",
-    
+
     # Children's Networks
     %w[DISNEY NICKELODEON CARTOON] => "America/New_York",
-    
+
     # Streaming Services (typically use Eastern for premieres)
     %w[NETFLIX HULU AMAZON PRIME] => "America/New_York"
   }.freeze
@@ -89,7 +89,7 @@ class UserSyncService
 
       # Parse air time and timezone information if available
       air_datetime_utc = parse_air_datetime(episode_data, series_details)
-      
+
       episode.assign_attributes(
         title: episode_data["name"] || "Episode #{episode_data['number']}",
         air_date: Date.parse(episode_data["aired"]),
@@ -125,19 +125,19 @@ class UserSyncService
     # Try to extract air time from various possible fields
     air_time = episode_data["airTime"] || episode_data["airsTime"] || episode_data["originalAirTime"]
     air_date = episode_data["aired"]
-    
+
     return nil unless air_date.present?
-    
+
     if air_time.present?
       # Combine date and time
       begin
         base_date = Date.parse(air_date)
         # Handle various time formats that TVDB might use
         time_str = "#{base_date} #{air_time}"
-        
+
         # Determine the source timezone
         source_timezone = extract_timezone(episode_data, series_details) || "America/New_York"
-        
+
         # Parse in the source timezone and convert to UTC
         source_tz = Time.find_zone(source_timezone)
         local_time = source_tz.parse(time_str)
@@ -146,7 +146,7 @@ class UserSyncService
         Rails.logger.warn "UserSyncService: Failed to parse air time '#{air_time}' for episode: #{e.message}"
       end
     end
-    
+
     # Fallback: use a default time if no specific time is available
     # Many shows air at 8 PM in their local timezone
     default_air_time = extract_default_air_time(series_details)
@@ -154,7 +154,7 @@ class UserSyncService
       begin
         base_date = Date.parse(air_date)
         source_timezone = extract_timezone(episode_data, series_details) || "America/New_York"
-        
+
         source_tz = Time.find_zone(source_timezone)
         default_datetime = source_tz.parse("#{base_date} #{default_air_time}")
         return default_datetime.utc if default_datetime
@@ -162,20 +162,20 @@ class UserSyncService
         Rails.logger.warn "UserSyncService: Failed to parse default air time '#{default_air_time}': #{e.message}"
       end
     end
-    
+
     nil
   end
 
   def extract_runtime(episode_data, series_details)
     # Try episode-specific runtime first
     runtime = episode_data["runtime"] || episode_data["runTime"] || episode_data["length"]
-    
+
     # Fall back to series default runtime
     runtime ||= series_details["averageRuntime"] || series_details["runtime"] || series_details["averageLength"]
-    
+
     # Convert to integer if it's a string
     runtime = runtime.to_i if runtime.is_a?(String) && runtime.match?(/^\d+$/)
-    
+
     runtime if runtime.is_a?(Integer) && runtime > 0
   end
 
@@ -183,13 +183,13 @@ class UserSyncService
     # Try to extract timezone information from various sources
     timezone = episode_data["timezone"] || episode_data["timeZone"]
     timezone ||= series_details["timezone"] || series_details["timeZone"]
-    
+
     # Check if series has network information that might indicate timezone
     if series_details["originalNetwork"].present?
       network = series_details["originalNetwork"]
       timezone ||= guess_timezone_from_network(network)
     end
-    
+
     # Default to EST/EDT since many US shows use this
     timezone || "America/New_York"
   end
@@ -198,28 +198,28 @@ class UserSyncService
     # Try to extract default air time from series details
     air_time = series_details["airTime"] || series_details["airsTime"] || series_details["originalAirTime"]
     return air_time if air_time.present?
-    
+
     # Some common defaults based on network patterns
     network = series_details["originalNetwork"]
     return "20:00" if network&.match?/(HBO|Showtime|FX|AMC)/i  # Premium/cable often 8 PM
     return "21:00" if network&.match?/(CBS|NBC|ABC|FOX)/i      # Broadcast often 9 PM
-    
+
     # General default
     "20:00" # 8 PM
   end
 
   def guess_timezone_from_network(network)
     return nil if network.blank?
-    
+
     # Find matching timezone from network mappings
     network_upper = network.to_s.upcase
-    
+
     NETWORK_TIMEZONE_MAPPINGS.each do |networks, timezone|
       if networks.any? { |net| network_upper.include?(net) }
         return timezone
       end
     end
-    
+
     nil # Let caller use default
   end
 end

--- a/app/services/user_sync_service.rb
+++ b/app/services/user_sync_service.rb
@@ -66,10 +66,16 @@ class UserSyncService
         episode_number: episode_data["number"]
       )
 
+      # Parse air time and timezone information if available
+      air_datetime_utc = parse_air_datetime(episode_data, series_details)
+      
       episode.assign_attributes(
         title: episode_data["name"] || "Episode #{episode_data['number']}",
         air_date: Date.parse(episode_data["aired"]),
-        is_season_finale: episode_data["finaleType"] == "season" || episode_data["finaleType"] == "series"
+        is_season_finale: episode_data["finaleType"] == "season" || episode_data["finaleType"] == "series",
+        air_datetime_utc: air_datetime_utc,
+        runtime_minutes: extract_runtime(episode_data, series_details),
+        original_timezone: extract_timezone(episode_data, series_details)
       )
 
       episode.save!
@@ -92,5 +98,106 @@ class UserSyncService
     )
 
     Rails.logger.info "UserSyncService: Broadcast sent to channel sync_#{@user.pin}"
+  end
+
+  def parse_air_datetime(episode_data, series_details)
+    # Try to extract air time from various possible fields
+    air_time = episode_data["airTime"] || episode_data["airsTime"] || episode_data["originalAirTime"]
+    air_date = episode_data["aired"]
+    
+    return nil unless air_date.present?
+    
+    if air_time.present?
+      # Combine date and time
+      begin
+        base_date = Date.parse(air_date)
+        # Handle various time formats that TVDB might use
+        time_str = "#{base_date} #{air_time}"
+        
+        # Determine the source timezone
+        source_timezone = extract_timezone(episode_data, series_details) || "America/New_York"
+        
+        # Parse in the source timezone and convert to UTC
+        Time.zone = source_timezone
+        local_time = Time.zone.parse(time_str)
+        return local_time.utc if local_time
+      rescue => e
+        Rails.logger.warn "UserSyncService: Failed to parse air time '#{air_time}' for episode: #{e.message}"
+      end
+    end
+    
+    # Fallback: use a default time if no specific time is available
+    # Many shows air at 8 PM in their local timezone
+    default_air_time = extract_default_air_time(series_details)
+    if default_air_time.present?
+      begin
+        base_date = Date.parse(air_date)
+        source_timezone = extract_timezone(episode_data, series_details) || "America/New_York"
+        
+        Time.zone = source_timezone
+        default_datetime = Time.zone.parse("#{base_date} #{default_air_time}")
+        return default_datetime.utc if default_datetime
+      rescue => e
+        Rails.logger.warn "UserSyncService: Failed to parse default air time '#{default_air_time}': #{e.message}"
+      end
+    end
+    
+    nil
+  end
+
+  def extract_runtime(episode_data, series_details)
+    # Try episode-specific runtime first
+    runtime = episode_data["runtime"] || episode_data["runTime"] || episode_data["length"]
+    
+    # Fall back to series default runtime
+    runtime ||= series_details["averageRuntime"] || series_details["runtime"] || series_details["averageLength"]
+    
+    # Convert to integer if it's a string
+    runtime = runtime.to_i if runtime.is_a?(String) && runtime.match?(/^\d+$/)
+    
+    runtime if runtime.is_a?(Integer) && runtime > 0
+  end
+
+  def extract_timezone(episode_data, series_details)
+    # Try to extract timezone information from various sources
+    timezone = episode_data["timezone"] || episode_data["timeZone"]
+    timezone ||= series_details["timezone"] || series_details["timeZone"]
+    
+    # Check if series has network information that might indicate timezone
+    if series_details["originalNetwork"].present?
+      network = series_details["originalNetwork"]
+      timezone ||= guess_timezone_from_network(network)
+    end
+    
+    # Default to EST/EDT since many US shows use this
+    timezone || "America/New_York"
+  end
+
+  def extract_default_air_time(series_details)
+    # Try to extract default air time from series details
+    air_time = series_details["airTime"] || series_details["airsTime"] || series_details["originalAirTime"]
+    return air_time if air_time.present?
+    
+    # Some common defaults based on network patterns
+    network = series_details["originalNetwork"]
+    return "20:00" if network&.match?/(HBO|Showtime|FX|AMC)/i  # Premium/cable often 8 PM
+    return "21:00" if network&.match?/(CBS|NBC|ABC|FOX)/i      # Broadcast often 9 PM
+    
+    # General default
+    "20:00" # 8 PM
+  end
+
+  def guess_timezone_from_network(network)
+    # Map common networks to their typical timezones
+    case network.to_s.upcase
+    when /HBO|SHOWTIME|MTV|VH1|COMEDY CENTRAL|FX|AMC/
+      "America/New_York"  # East Coast
+    when /FOX|ABC|CBS|NBC|CW/
+      "America/New_York"  # Major networks typically reference Eastern
+    when /DISNEY|NICKELODEON/
+      "America/New_York"
+    else
+      nil # Let caller use default
+    end
   end
 end

--- a/app/services/user_sync_service.rb
+++ b/app/services/user_sync_service.rb
@@ -118,8 +118,8 @@ class UserSyncService
         source_timezone = extract_timezone(episode_data, series_details) || "America/New_York"
         
         # Parse in the source timezone and convert to UTC
-        Time.zone = source_timezone
-        local_time = Time.zone.parse(time_str)
+        source_tz = Time.find_zone(source_timezone)
+        local_time = source_tz.parse(time_str)
         return local_time.utc if local_time
       rescue => e
         Rails.logger.warn "UserSyncService: Failed to parse air time '#{air_time}' for episode: #{e.message}"
@@ -134,8 +134,8 @@ class UserSyncService
         base_date = Date.parse(air_date)
         source_timezone = extract_timezone(episode_data, series_details) || "America/New_York"
         
-        Time.zone = source_timezone
-        default_datetime = Time.zone.parse("#{base_date} #{default_air_time}")
+        source_tz = Time.find_zone(source_timezone)
+        default_datetime = source_tz.parse("#{base_date} #{default_air_time}")
         return default_datetime.utc if default_datetime
       rescue => e
         Rails.logger.warn "UserSyncService: Failed to parse default air time '#{default_air_time}': #{e.message}"

--- a/db/migrate/20250721022800_add_air_time_and_runtime_to_episodes.rb
+++ b/db/migrate/20250721022800_add_air_time_and_runtime_to_episodes.rb
@@ -4,7 +4,7 @@ class AddAirTimeAndRuntimeToEpisodes < ActiveRecord::Migration[8.0]
     add_column :episodes, :runtime_minutes, :integer
     add_column :episodes, :original_timezone, :string
     add_column :episodes, :air_datetime_utc, :datetime
-    
+
     add_index :episodes, :air_datetime_utc
   end
 end

--- a/db/migrate/20250721022800_add_air_time_and_runtime_to_episodes.rb
+++ b/db/migrate/20250721022800_add_air_time_and_runtime_to_episodes.rb
@@ -1,0 +1,10 @@
+class AddAirTimeAndRuntimeToEpisodes < ActiveRecord::Migration[8.0]
+  def change
+    add_column :episodes, :air_time, :datetime
+    add_column :episodes, :runtime_minutes, :integer
+    add_column :episodes, :original_timezone, :string
+    add_column :episodes, :air_datetime_utc, :datetime
+    
+    add_index :episodes, :air_datetime_utc
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_20_211037) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_21_022800) do
   create_table "episodes", force: :cascade do |t|
     t.integer "series_id", null: false
     t.string "title", null: false
@@ -20,7 +20,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_20_211037) do
     t.boolean "is_season_finale", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "air_time"
+    t.integer "runtime_minutes"
+    t.string "original_timezone"
+    t.datetime "air_datetime_utc"
     t.index ["air_date"], name: "index_episodes_on_air_date"
+    t.index ["air_datetime_utc"], name: "index_episodes_on_air_datetime_utc"
     t.index ["series_id", "season_number", "episode_number"], name: "idx_on_series_id_season_number_episode_number_ac8d2e3ce3", unique: true
     t.index ["series_id"], name: "index_episodes_on_series_id"
   end

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -169,7 +169,7 @@ class EpisodeTest < ActiveSupport::TestCase
   test "air_time_in_timezone should convert to target timezone" do
     utc_time = Time.parse("2025-07-21 20:00:00 UTC")
     @episode.air_datetime_utc = utc_time
-    
+
     ny_time = @episode.air_time_in_timezone("America/New_York")
     assert_equal "16:00", ny_time.strftime("%H:%M") # 8 PM UTC = 4 PM EDT
   end
@@ -190,7 +190,7 @@ class EpisodeTest < ActiveSupport::TestCase
     utc_time = Time.parse("2025-07-21 20:00:00 UTC")
     @episode.air_datetime_utc = utc_time
     @episode.runtime_minutes = 60
-    
+
     end_time = @episode.end_time_in_timezone("America/New_York")
     assert_equal "17:00", end_time.strftime("%H:%M") # 4 PM + 1 hour = 5 PM
   end

--- a/test/services/ics_generator_test.rb
+++ b/test/services/ics_generator_test.rb
@@ -62,8 +62,9 @@ class IcsGeneratorTest < ActiveSupport::TestCase
 
     # Check date format
     date_str = (@episode.air_date).strftime("%Y%m%d")
+    date_end = (@episode.air_date + 1.day).strftime("%Y%m%d")
     assert_includes ics_content, "DTSTART;VALUE=DATE:#{date_str}"
-    assert_includes ics_content, "DTEND;VALUE=DATE:#{date_str}"
+    assert_includes ics_content, "DTEND;VALUE=DATE:#{date_end}"
   end
 
   test "should include IMDB URL when available" do
@@ -146,7 +147,7 @@ class IcsGeneratorTest < ActiveSupport::TestCase
     # Should use TZID format instead of VALUE=DATE
     assert_includes ics_content, "DTSTART;TZID=America/New_York:20250721T160000"
     assert_includes ics_content, "DTEND;TZID=America/New_York:20250721T170000"
-    
+
     # Should not include VALUE=DATE format
     assert_not_includes ics_content, "VALUE=DATE"
   end
@@ -158,9 +159,10 @@ class IcsGeneratorTest < ActiveSupport::TestCase
 
     # Should use VALUE=DATE format
     date_str = @episode.air_date.strftime("%Y%m%d")
+    date_end = (@episode.air_date + 1.day).strftime("%Y%m%d")
     assert_includes ics_content, "DTSTART;VALUE=DATE:#{date_str}"
-    assert_includes ics_content, "DTEND;VALUE=DATE:#{date_str}"
-    
+    assert_includes ics_content, "DTEND;VALUE=DATE:#{date_end}"
+
     # Should not include TZID format
     assert_not_includes ics_content, "TZID=America/New_York"
   end
@@ -180,19 +182,20 @@ class IcsGeneratorTest < ActiveSupport::TestCase
   end
 
   test "should handle winter timezone (EST) correctly" do
-    # Set air time in winter (EST, UTC-5)
-    air_time_utc = Time.parse("2025-01-15 21:00:00 UTC")
+    # Set air time in winter (EST, UTC-5) - use future date
+    future_winter_date = Date.parse("2026-01-15")
+    air_time_utc = Time.parse("2026-01-15 21:00:00 UTC")
     @episode.update!(
       air_datetime_utc: air_time_utc,
       runtime_minutes: 30,
-      air_date: Date.parse("2025-01-15")
+      air_date: future_winter_date
     )
 
     ics_content = @generator.generate
 
     # 9 PM UTC in winter = 4 PM EST
-    assert_includes ics_content, "DTSTART;TZID=America/New_York:20250115T160000"
-    assert_includes ics_content, "DTEND;TZID=America/New_York:20250115T163000"
+    assert_includes ics_content, "DTSTART;TZID=America/New_York:20260115T160000"
+    assert_includes ics_content, "DTEND;TZID=America/New_York:20260115T163000"
   end
 
   test "should handle mixed episodes with and without air times" do


### PR DESCRIPTION
Implements air time and runtime support for TV episodes as requested in #13.

## Changes
- Add database fields for air time, runtime, and timezone information
- Update sync service to extract timing data from TVDB API
- Implement timezone conversion: TVDB → UTC → NY timezone
- Generate timed calendar events instead of all-day events
- Maintain backward compatibility with existing functionality

## Testing
Please run:
- `rails db:migrate` to add database fields
- `rails test` to verify functionality
- `rubocop` for code style compliance

Fixes #13

🤖 Generated with [Claude Code](https://claude.ai/code)