### PR TITLE
Normalize series schema to eliminate duplicate series records

### DIFF
--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -1,6 +1,6 @@
 class Episode < ApplicationRecord
   belongs_to :series
-  has_one :user, through: :series
+  has_many :users, through: :series
 
   validates :title, presence: true
   validates :season_number, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1,8 +1,9 @@
 class Series < ApplicationRecord
-  belongs_to :user
+  has_many :user_series, dependent: :destroy
+  has_many :users, through: :user_series
   has_many :episodes, dependent: :destroy
 
-  validates :tvdb_id, presence: true, uniqueness: { scope: :user_id }
+  validates :tvdb_id, presence: true, uniqueness: true
   validates :name, presence: true
 
   def imdb_url

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ApplicationRecord
   validates :pin, presence: true, uniqueness: true
 
-  has_many :series, dependent: :destroy
+  has_many :user_series, dependent: :destroy
+  has_many :series, through: :user_series
   has_many :episodes, through: :series
 
   def needs_sync?

--- a/app/models/user_series.rb
+++ b/app/models/user_series.rb
@@ -1,0 +1,6 @@
+class UserSeries < ApplicationRecord
+  belongs_to :user
+  belongs_to :series
+
+  validates :user_id, uniqueness: { scope: :series_id }
+end

--- a/app/services/user_sync_service.rb
+++ b/app/services/user_sync_service.rb
@@ -75,9 +75,11 @@ class UserSyncService
     )
     series.save!
 
-    # Associate series with user if not already associated
-    unless @user.series.include?(series)
-      @user.user_series.create!(series: series)
+    # Associate series with user (handles race conditions gracefully)
+    begin
+      @user.user_series.find_or_create_by!(series: series)
+    rescue ActiveRecord::RecordNotUnique
+      # Association already exists, continue
     end
 
     # Get episodes for this series

--- a/db/migrate/20250721030649_normalize_series_schema.rb
+++ b/db/migrate/20250721030649_normalize_series_schema.rb
@@ -1,0 +1,59 @@
+class NormalizeSeriesSchema < ActiveRecord::Migration[8.0]
+  def up
+    # Create join table for users and series
+    create_table :user_series do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :series, null: false, foreign_key: true
+      t.timestamps
+    end
+
+    # Add unique constraint to prevent duplicate user-series associations
+    add_index :user_series, [ :user_id, :series_id ], unique: true
+
+    # Migrate existing data: populate user_series join table
+    execute <<-SQL
+      INSERT INTO user_series (user_id, series_id, created_at, updated_at)
+      SELECT user_id, id, created_at, updated_at FROM series
+    SQL
+
+    # Remove foreign key constraint from series to users
+    remove_foreign_key :series, :users
+
+    # Remove user_id column from series
+    remove_column :series, :user_id, :integer
+
+    # Remove the old composite unique index (user_id, tvdb_id)
+    remove_index :series, [ :user_id, :tvdb_id ] if index_exists?(:series, [ :user_id, :tvdb_id ])
+
+    # Add unique constraint on tvdb_id to prevent duplicate series
+    add_index :series, :tvdb_id, unique: true
+  end
+
+  def down
+    # Add user_id back to series
+    add_column :series, :user_id, :integer, null: false
+
+    # Restore foreign key
+    add_foreign_key :series, :users
+
+    # Migrate data back: set user_id from first association in join table
+    execute <<-SQL
+      UPDATE series#{' '}
+      SET user_id = (
+        SELECT user_id#{' '}
+        FROM user_series#{' '}
+        WHERE user_series.series_id = series.id#{' '}
+        LIMIT 1
+      )
+    SQL
+
+    # Remove the tvdb_id unique index
+    remove_index :series, :tvdb_id if index_exists?(:series, :tvdb_id)
+
+    # Add back the composite index
+    add_index :series, [ :user_id, :tvdb_id ], unique: true
+
+    # Drop the join table
+    drop_table :user_series
+  end
+end

--- a/db/migrate/20250721030649_normalize_series_schema.rb
+++ b/db/migrate/20250721030649_normalize_series_schema.rb
@@ -30,8 +30,8 @@ class NormalizeSeriesSchema < ActiveRecord::Migration[8.0]
   end
 
   def down
-    # Add user_id back to series
-    add_column :series, :user_id, :integer, null: false
+    # Add user_id back to series (nullable initially for safe rollback)
+    add_column :series, :user_id, :integer
 
     # Restore foreign key
     add_foreign_key :series, :users

--- a/db/migrate/20250721032146_fix_schema_issues.rb
+++ b/db/migrate/20250721032146_fix_schema_issues.rb
@@ -1,0 +1,15 @@
+class FixSchemaIssues < ActiveRecord::Migration[8.0]
+  def up
+    # Remove duplicate index that has incorrect name
+    if index_exists?(:series, :tvdb_id, name: "index_series_on_user_id_and_tvdb_id")
+      remove_index :series, name: "index_series_on_user_id_and_tvdb_id"
+    end
+  end
+
+  def down
+    # Re-add the index if needed (though it was incorrect)
+    unless index_exists?(:series, :tvdb_id, name: "index_series_on_user_id_and_tvdb_id")
+      add_index :series, :tvdb_id, name: "index_series_on_user_id_and_tvdb_id", unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_21_022800) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_21_030649) do
   create_table "episodes", force: :cascade do |t|
     t.integer "series_id", null: false
     t.string "title", null: false
@@ -31,14 +31,23 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_21_022800) do
   end
 
   create_table "series", force: :cascade do |t|
-    t.integer "user_id", null: false
     t.integer "tvdb_id", null: false
     t.string "name", null: false
     t.string "imdb_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id", "tvdb_id"], name: "index_series_on_user_id_and_tvdb_id", unique: true
-    t.index ["user_id"], name: "index_series_on_user_id"
+    t.index ["tvdb_id"], name: "index_series_on_tvdb_id", unique: true
+    t.index ["tvdb_id"], name: "index_series_on_user_id_and_tvdb_id", unique: true
+  end
+
+  create_table "user_series", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "series_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["series_id"], name: "index_user_series_on_series_id"
+    t.index ["user_id", "series_id"], name: "index_user_series_on_user_id_and_series_id", unique: true
+    t.index ["user_id"], name: "index_user_series_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -50,5 +59,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_21_022800) do
   end
 
   add_foreign_key "episodes", "series"
-  add_foreign_key "series", "users"
+  add_foreign_key "user_series", "series"
+  add_foreign_key "user_series", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_21_030649) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_21_032146) do
   create_table "episodes", force: :cascade do |t|
     t.integer "series_id", null: false
     t.string "title", null: false
@@ -37,7 +37,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_21_030649) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["tvdb_id"], name: "index_series_on_tvdb_id", unique: true
-    t.index ["tvdb_id"], name: "index_series_on_user_id_and_tvdb_id", unique: true
   end
 
   create_table "user_series", force: :cascade do |t|

--- a/test/controllers/calendar_controller_test.rb
+++ b/test/controllers/calendar_controller_test.rb
@@ -4,11 +4,11 @@ class CalendarControllerTest < ActionDispatch::IntegrationTest
   def setup
     @user = User.create!(pin: "calendar_test_#{rand(100000..999999)}")
     @series = Series.create!(
-      user: @user,
-      tvdb_id: 123,
+      tvdb_id: rand(100000..999999),
       name: "Test Series",
       imdb_id: "tt1234567"
     )
+    @user.user_series.create!(series: @series)
     @episode = Episode.create!(
       series: @series,
       title: "Test Episode",

--- a/test/fixtures/series.yml
+++ b/test/fixtures/series.yml
@@ -1,13 +1,11 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  user: one
   tvdb_id: 123
   name: "Test Series One"
   imdb_id: "tt1234567"
 
 two:
-  user: two
   tvdb_id: 456
   name: "Test Series Two"
   imdb_id: "tt7654321"

--- a/test/fixtures/user_series.yml
+++ b/test/fixtures/user_series.yml
@@ -1,0 +1,14 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  series: one
+
+two:
+  user: two
+  series: two
+
+# Allow user one to also have series two (many-to-many relationship)
+three:
+  user: one
+  series: two

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -4,10 +4,10 @@ class EpisodeTest < ActiveSupport::TestCase
   def setup
     @user = User.create!(pin: "episode_test_#{rand(100000..999999)}")
     @series = Series.create!(
-      user: @user,
-      tvdb_id: 123,
+      tvdb_id: rand(100000..999999),
       name: "Test Series"
     )
+    @user.user_series.create!(series: @series)
     @episode = Episode.new(
       series: @series,
       title: "Test Episode",
@@ -62,9 +62,9 @@ class EpisodeTest < ActiveSupport::TestCase
     assert_equal @series, @episode.series
   end
 
-  test "should have user through series" do
-    assert_respond_to @episode, :user
-    assert_equal @user, @episode.user
+  test "should have users through series" do
+    assert_respond_to @episode, :users
+    assert_includes @episode.users, @user
   end
 
   test "episode_code should format correctly with single digits" do

--- a/test/services/ics_generator_test.rb
+++ b/test/services/ics_generator_test.rb
@@ -4,11 +4,11 @@ class IcsGeneratorTest < ActiveSupport::TestCase
   def setup
     @user = User.create!(pin: "ics_test_#{rand(100000..999999)}")
     @series = Series.create!(
-      user: @user,
-      tvdb_id: 123,
+      tvdb_id: rand(100000..999999),
       name: "Test Series",
       imdb_id: "tt1234567"
     )
+    @user.user_series.create!(series: @series)
     @episode = Episode.create!(
       series: @series,
       title: "Test Episode",


### PR DESCRIPTION
**Schema Changes:**
- Remove user_id from series table
- Add unique constraint on series.tvdb_id
- Create user_series join table for many-to-many relationship
- Migrate existing data to preserve associations

**Model Updates:**
- Series: Remove belongs_to :user, add has_many :users through :user_series
- User: Change has_many :series to through :user_series
- Episode: Change has_one :user to has_many :users through :series
- Add UserSeries join model with validations

**Service Updates:**
- UserSyncService: Find or create series globally, then associate with user
- Prevents duplicate series creation for same TVDB ID
- Multiple users can now favorite the same series

**Benefits:**
- Eliminates duplicate series/episode records
- Reduces storage and improves data consistency
- Enables better series data sharing across users
- Maintains backwards compatibility through migration

🤖 Generated with [Claude Code](https://claude.ai/code)