### PR TITLE
Configure SolidQueue for development environment

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ module Tvdbcalendar
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "UTC"
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,8 +17,13 @@ postgresql: &postgresql
   timeout: 5000
 
 development:
-  <<: *default
-  database: storage/development.sqlite3
+  primary:
+    <<: *default
+    database: storage/development.sqlite3
+  queue:
+    <<: *default
+    database: storage/development_queue.sqlite3
+    migrations_paths: db/queue_migrate
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,6 +55,14 @@ Rails.application.configure do
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
 
+  # Configure SolidQueue as the ActiveJob adapter
+  config.active_job.queue_adapter = :solid_queue
+  config.solid_queue.connects_to = { database: { writing: :queue } }
+
+  # Configure SolidQueue logging for better visibility
+  config.solid_queue.logger = Logger.new(STDOUT)
+  config.solid_queue.logger.level = Logger::INFO
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 


### PR DESCRIPTION
## Summary
- Configure SolidQueue for development environment per documentation
- Add separate queue database configuration using SQLite
- Set SolidQueue as ActiveJob adapter with proper logging
- Set default Rails timezone to UTC

## Changes Made
- **config/database.yml**: Added queue database configuration for development
- **config/environments/development.rb**: Configured SolidQueue adapter and logging
- **config/application.rb**: Set default timezone to UTC

## Test Plan
- [x] All tests pass (92 tests, 0 failures)
- [x] RuboCop linting passes with no violations
- [x] `bin/jobs` runs successfully with visible logging
- [x] SolidQueue scheduler recognizes recurring jobs
- [x] Database configuration loads without errors

## Usage
Run background jobs separately from Rails server:
```bash
bin/jobs
```

Jobs will now process in development with full logging visibility.

🤖 Generated with [Claude Code](https://claude.ai/code)