### PR TITLE
Add ALLOWED_HOSTS environment variable support for proxy hosts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get update -qq && \
 ENV RAILS_ENV="production" \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle" \
-    BUNDLE_WITHOUT="development"
+    BUNDLE_WITHOUT="development" \
+    ALLOWED_HOSTS=""
 
 # Throw-away build stage to reduce size of final image
 FROM base AS build

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,7 +87,12 @@ Rails.application.configure do
   #   "example.com",     # Allow requests from example.com
   #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
   # ]
-  #
+  
+  # Configure allowed hosts from environment variable for proxy support
+  if ENV["ALLOWED_HOSTS"].present?
+    config.hosts = ENV["ALLOWED_HOSTS"].split(",").map(&:strip)
+  end
+  
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
Fixes #27

Adds support for proxy hosts by implementing an ALLOWED_HOSTS environment variable:

- **Dockerfile**: Added ALLOWED_HOSTS environment variable
- **production.rb**: Added conditional config.hosts setup using environment variable
- **Usage**: Set ALLOWED_HOSTS="example.com,*.example.com" for comma-separated host list

This resolves the HTTP Origin header mismatch errors when using proxy servers.

Generated with [Claude Code](https://claude.ai/code)