### PR TITLE
Refactor sync logic into consolidated SeriesSyncService

### DIFF
--- a/app/jobs/series_sync_job.rb
+++ b/app/jobs/series_sync_job.rb
@@ -36,17 +36,8 @@ class SeriesSyncJob < ApplicationJob
   def sync_series_data(series)
     client = TvdbClient.new
 
-    # Get updated series details
-    series_details = client.get_series_details(series.tvdb_id)
-
-    # Update series information
-    series.update!(
-      name: series_details["name"],
-      imdb_id: series_details["remoteIds"]&.find { |r| r["sourceName"] == "IMDB" }&.dig("id")
-    )
-
-    # Also sync episodes for this series using shared service
-    episode_sync_service = EpisodeSyncService.new(client)
-    episode_sync_service.sync_episodes_for_series(series, series_details)
+    # Use consolidated service for all series sync operations
+    series_sync_service = SeriesSyncService.new(client)
+    series_sync_service.sync_series_data(series)
   end
 end

--- a/app/services/user_sync_service.rb
+++ b/app/services/user_sync_service.rb
@@ -81,13 +81,13 @@ class UserSyncService
       # Association already exists, continue
     end
 
-    # Sync episodes using shared service (only if new series or needs sync)
+    # Sync episodes using consolidated service (only if new series or needs sync)
     # For existing series, we may need series details for episode processing
     # Only fetch if we didn't already get it for a new series
     series_details = defined?(series_details) ? series_details : nil
 
-    episode_sync_service = EpisodeSyncService.new(@client)
-    episode_sync_service.sync_episodes_for_series(series, series_details)
+    series_sync_service = SeriesSyncService.new(@client)
+    series_sync_service.sync_episodes_for_series(series, series_details)
 
     # Mark series as synced since we just processed it (new series already have timestamp set)
     series.mark_as_synced! unless is_new_series

--- a/test/services/series_sync_service_test.rb
+++ b/test/services/series_sync_service_test.rb
@@ -1,13 +1,13 @@
 require "test_helper"
 
-class EpisodeSyncServiceTest < ActiveSupport::TestCase
+class SeriesSyncServiceTest < ActiveSupport::TestCase
   def setup
     @series = Series.create!(
       tvdb_id: rand(100000..999999),
       name: "Test Series"
     )
     @mock_client = Object.new
-    @service = EpisodeSyncService.new(@mock_client)
+    @service = SeriesSyncService.new(@mock_client)
   end
 
   test "should sync episodes for series" do
@@ -52,14 +52,14 @@ class EpisodeSyncServiceTest < ActiveSupport::TestCase
 
   test "should handle timezone detection from network" do
     # Test that network timezone mappings are correctly defined
-    assert EpisodeSyncService::NETWORK_TIMEZONE_MAPPINGS.present?
-    assert_equal "America/New_York", EpisodeSyncService::NETWORK_TIMEZONE_MAPPINGS[%w[HBO SHOWTIME STARZ EPIX]]
+    assert SeriesSyncService::NETWORK_TIMEZONE_MAPPINGS.present?
+    assert_equal "America/New_York", SeriesSyncService::NETWORK_TIMEZONE_MAPPINGS[%w[HBO SHOWTIME STARZ EPIX]]
   end
 
   test "should extract default air times based on network" do
     # Test that HBO series get 8 PM default
     series_details_hbo = { "originalNetwork" => "HBO" }
-    service = EpisodeSyncService.new(@mock_client)
+    service = SeriesSyncService.new(@mock_client)
     default_time = service.send(:extract_default_air_time, series_details_hbo)
     assert_equal "20:00", default_time
 

--- a/test/services/series_sync_service_test.rb
+++ b/test/services/series_sync_service_test.rb
@@ -107,4 +107,84 @@ class SeriesSyncServiceTest < ActiveSupport::TestCase
     episode = @series.episodes.first
     assert_equal "Valid Episode", episode.title
   end
+
+  test "should sync series data and episodes" do
+    # Mock series details from TVDB API
+    series_details = {
+      "name" => "Updated Series Name",
+      "remoteIds" => [
+        { "sourceName" => "IMDB", "id" => "tt1234567" },
+        { "sourceName" => "TheMovieDB", "id" => "987654" }
+      ],
+      "originalNetwork" => "HBO"
+    }
+
+    # Mock episodes data
+    episodes_data = [
+      {
+        "name" => "Pilot",
+        "aired" => "2023-01-01",
+        "seasonNumber" => 1,
+        "number" => 1,
+        "finaleType" => "regular"
+      }
+    ]
+
+    # Set up mock client methods
+    @mock_client.define_singleton_method(:get_series_details) { |tvdb_id| series_details }
+    @mock_client.define_singleton_method(:get_series_episodes) { |tvdb_id| episodes_data }
+
+    # Call the main sync method
+    @service.sync_series_data(@series)
+
+    # Verify series data was updated
+    @series.reload
+    assert_equal "Updated Series Name", @series.name
+    assert_equal "tt1234567", @series.imdb_id
+
+    # Verify episodes were synced
+    assert_equal 1, @series.episodes.count
+    episode = @series.episodes.first
+    assert_equal "Pilot", episode.title
+    assert_equal Date.parse("2023-01-01"), episode.air_date
+    assert_equal 1, episode.season_number
+    assert_equal 1, episode.episode_number
+  end
+
+  test "should handle series with no IMDB ID" do
+    series_details = {
+      "name" => "Series Without IMDB",
+      "remoteIds" => [
+        { "sourceName" => "TheMovieDB", "id" => "987654" }
+      ]
+    }
+
+    episodes_data = []
+
+    @mock_client.define_singleton_method(:get_series_details) { |tvdb_id| series_details }
+    @mock_client.define_singleton_method(:get_series_episodes) { |tvdb_id| episodes_data }
+
+    @service.sync_series_data(@series)
+
+    @series.reload
+    assert_equal "Series Without IMDB", @series.name
+    assert_nil @series.imdb_id
+  end
+
+  test "should handle series with no remoteIds" do
+    series_details = {
+      "name" => "Series Without Remote IDs"
+    }
+
+    episodes_data = []
+
+    @mock_client.define_singleton_method(:get_series_details) { |tvdb_id| series_details }
+    @mock_client.define_singleton_method(:get_series_episodes) { |tvdb_id| episodes_data }
+
+    @service.sync_series_data(@series)
+
+    @series.reload
+    assert_equal "Series Without Remote IDs", @series.name
+    assert_nil @series.imdb_id
+  end
 end


### PR DESCRIPTION
## Summary
- Consolidated EpisodeSyncService functionality into SeriesSyncService for better organization
- Updated UserSyncService and SeriesSyncJob to use the new consolidated service  
- Moved all episode sync logic, timezone mappings, and network detection into single service
- Updated and renamed test files to reflect the new service structure

## Test plan
- [x] All existing tests pass with the new service structure
- [x] SeriesSyncService tests cover episode sync functionality
- [x] UserSyncService integration works with consolidated service
- [x] SeriesSyncJob integration works with consolidated service
- [x] RuboCop compliance maintained

🤖 Generated with [Claude Code](https://claude.ai/code)