### PR TITLE
Add user sync trigger to admin interface

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -43,10 +43,6 @@ ActiveAdmin.register User do
       end
     end
 
-    panel "Actions" do
-      link_to "Trigger Sync", sync_admin_user_path(user), method: :post, class: "button", confirm: "Queue sync job for this user?"
-    end
-
     panel "Series" do
       table_for user.series.limit(10) do
         column :name do |series|
@@ -55,6 +51,10 @@ ActiveAdmin.register User do
         column :tvdb_id
         column :last_synced_at
       end
+    end
+
+    panel "Actions" do
+      link_to "Trigger Sync", sync_admin_user_path(user), method: :post, class: "button", confirm: "Queue sync job for this user?"
     end
   end
 end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -2,6 +2,11 @@ ActiveAdmin.register User do
   menu priority: 1
   permit_params :pin, :last_synced_at
 
+  member_action :sync, method: :post do
+    UserSyncIndividualJob.perform_later(resource.pin, force: true)
+    redirect_to resource_path(resource), notice: "Sync job queued for user #{resource.pin}"
+  end
+
   index do
     selectable_column
     id_column
@@ -14,7 +19,9 @@ ActiveAdmin.register User do
       status_tag(user.needs_sync? ? "Yes" : "No", class: user.needs_sync? ? "error" : "ok")
     end
     column :created_at
-    actions
+    actions do |user|
+      link_to "Sync", sync_admin_user_path(user), method: :post, class: "member_link", confirm: "Queue sync job for this user?"
+    end
   end
 
   filter :pin
@@ -34,6 +41,10 @@ ActiveAdmin.register User do
       row :needs_sync? do |user|
         status_tag(user.needs_sync? ? "Yes" : "No", class: user.needs_sync? ? "error" : "ok")
       end
+    end
+
+    panel "Actions" do
+      link_to "Trigger Sync", sync_admin_user_path(user), method: :post, class: "button", confirm: "Queue sync job for this user?"
     end
 
     panel "Series" do


### PR DESCRIPTION
## Summary
- Add sync action to ActiveAdmin user interface
- Allow admins to manually trigger user syncs with force flag
- Add sync buttons to both index and show pages

## Changes
- Add member_action :sync to users.rb admin resource
- Queue UserSyncIndividualJob with force: true parameter
- Add sync button to user index actions column
- Add sync button to user show page Actions panel
- Include confirmation dialogs for both buttons

## Test plan
- [ ] Verify sync button appears in user index table
- [ ] Verify sync button appears on user show page
- [ ] Confirm clicking sync button queues job and shows success message
- [ ] Test with existing user to ensure sync completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)