### PR TITLE
Fix Docker build failure in GitHub Actions

### DIFF
--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -11,6 +11,7 @@ on:
       - 'app/**'
       - 'lib/**'
       - '.github/workflows/docker-build-check.yml'
+      - '.github/workflows/docker-publish.yml'
 
 jobs:
   docker-build:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,35 +43,22 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,format=short
 
+      - name: Get short SHA
+        id: vars
+        run: echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
       - name: Build and push Docker image
-        run: |
-          TAGS="${{ steps.meta.outputs.tags }}"
-          LABELS="${{ steps.meta.outputs.labels }}"
-          
-          # Convert newline-separated tags to multiple --tag arguments
-          TAG_ARGS=""
-          while IFS= read -r tag; do
-            if [ -n "$tag" ]; then
-              TAG_ARGS="$TAG_ARGS --tag $tag"
-            fi
-          done <<< "$TAGS"
-          
-          # Convert newline-separated labels to multiple --label arguments  
-          LABEL_ARGS=""
-          while IFS= read -r label; do
-            if [ -n "$label" ]; then
-              LABEL_ARGS="$LABEL_ARGS --label $label"
-            fi
-          done <<< "$LABELS"
-          
-          ./bin/docker-build \
-            --platform linux/amd64,linux/arm64 \
-            --push \
-            $TAG_ARGS \
-            $LABEL_ARGS \
-            --cache-from type=gha \
-            --cache-to type=gha,mode=max \
-            .
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ steps.vars.outputs.short_sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Generate image summary
         run: |


### PR DESCRIPTION
## Summary
- Fixes Docker build failure caused by argument parsing issues with custom script
- Switches back to `docker/build-push-action` for reliability in CI
- Adds APP_VERSION build arg using calculated short SHA
- Restores commit SHA tagging for version-specific image pulls

## Root Cause
The custom `bin/docker-build` script was having issues with complex argument parsing in GitHub Actions when handling multiple tags, labels, and build flags.

## Solution
- Use standard `docker/build-push-action` in CI (more reliable)
- Calculate short SHA with `${GITHUB_SHA::7}` 
- Pass as `APP_VERSION` build arg
- Keep custom script available for local development

## Test Plan
- [ ] GitHub Actions build completes successfully
- [ ] Docker images are tagged with commit SHA (e.g., `:a4e1dc5`)
- [ ] APP_VERSION environment variable is set in container
- [ ] Version footer displays commit hash in production

🤖 Generated with [Claude Code](https://claude.ai/code)